### PR TITLE
Move reduceToExcerpt() tests to own file

### DIFF
--- a/src/components/Excerpt/index.test.js
+++ b/src/components/Excerpt/index.test.js
@@ -1,37 +1,8 @@
 import React from 'react';
-import { render, unmountComponentAtNode } from 'react-dom';
+import ReactDOM from 'react-dom';
 import Excerpt from './';
 
-[
-  [ 'Hi everybody', 4, 'Hi' ],
-  [ '12 3456', 2, '12' ],
-  [ 'One two three', 4, 'One' ],
-  [ 'One  two three', 4, 'One' ],
-  [ '      One two three', 3, 'One' ],
-  [ 'Hi everybody', 4, 'Hi' ],
-  [ '12 345678', 4, '12' ],
-  [ '      helllo hello', 10, 'helllo' ],
-  [ 'abc def  ', 10, 'abc def' ],
-  [ '<strong>One two three</strong>', 5, 'One' ],
-  [ '                ', 5, '' ],
-  [ 'One ', 4, 'One' ],
-  [ ' One ', 5, 'One' ],
-  [ 'encyclopedia', 5, '' ],
-].map(
-  ([content, maxChars, expected], index) => {
-    const container = document.createElement('div');
-    it(`renders the correct length substring ${index}`, () => {
-      render(
-        <Excerpt
-          content={content}
-          maxChars={maxChars}
-        />,
-        container
-      );
-      expect(container.textContent).toBe(expected);
-    });
-    // Cleanup.
-    unmountComponentAtNode(container);
-    container.remove();
-  }
-);
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+  ReactDOM.render(<Excerpt />, div);
+});

--- a/src/utilities/reduceToExcerpt.test.js
+++ b/src/utilities/reduceToExcerpt.test.js
@@ -1,0 +1,26 @@
+import reduceToExcerpt from './reduceToExcerpt.js';
+
+[
+  [ 'Hi everybody', 4, 'Hi' ],
+  [ '12 3456', 2, '12' ],
+  [ 'One two three', 4, 'One' ],
+  [ 'One  two three', 4, 'One' ],
+  [ '      One two three', 3, 'One' ],
+  [ 'Hi everybody', 4, 'Hi' ],
+  [ '12 345678', 4, '12' ],
+  [ '      helllo hello', 10, 'helllo' ],
+  [ 'abc def  ', 10, 'abc def' ],
+  [ '<strong>One two three</strong>', 5, 'One' ],
+  [ '                ', 5, '' ],
+  [ 'One ', 4, 'One' ],
+  [ ' One ', 5, 'One' ],
+  [ 'encyclopedia', 5, '' ],
+].map(
+  ([content, maxChars, expected], index) => {
+    it(`renders the correct length substring ${index}`, () => {
+      expect(
+        reduceToExcerpt(content, maxChars)
+      ).toBe(expected);
+    });
+  }
+);


### PR DESCRIPTION
Move reduceToExcerpt() tests to own file instead of using them as part
of the Excerpt component tests.